### PR TITLE
issue resolved #19(Add Reset Button to Revert File to Original)

### DIFF
--- a/content.js
+++ b/content.js
@@ -276,6 +276,44 @@ window.addEventListener("message", (event) => {
     console.error("[FormEase] Replacement failed:", err);
     showError(toolbox, "Failed to update file. Please try again.");
   }
+
+  // Handle Reset Request
+  if (type === "requestReset") {
+    const { inputId } = event.data;
+    const input = document.querySelector(`input[data-form-ease-id="${inputId}"]`);
+    const toolbox = document.querySelector(`.formease-toolbox[data-input-id="${inputId}"]`);
+    const feedbackArea = toolbox.querySelector(".formease-feedback");
+
+    if (!input) {
+      showError(toolbox, "Input not found.");
+      return;
+    }
+
+    if (originalFiles && originalFiles.has(inputId)) {
+      const originalFile = originalFiles.get(inputId);
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(originalFile);
+      const hiddenInput = document.createElement("input");
+      hiddenInput.type = "file";
+      hiddenInput.style.display = "none";
+      hiddenInput.files = dataTransfer.files;
+      input.parentNode.insertBefore(hiddenInput, input);
+      input.parentNode.removeChild(input);
+      input.parentNode.appendChild(input);
+      hiddenInput.dispatchEvent(new Event("change", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+
+      showDetailedSuccessMessage(toolbox, "Original file restored.");
+      feedbackArea.innerHTML = ""; // Clear success messages
+      // Clear previews or processed outputs (assuming #previewArea or similar)
+      const previewArea = toolbox.querySelector("#previewArea");
+      if (previewArea) previewArea.innerHTML = "";
+      setTimeout(() => (feedbackArea.style.display = "none"), 3000);
+    } else {
+      showError(toolbox, "No original file found to reset.");
+      setTimeout(() => (feedbackArea.style.display = "none"), 3000);
+    }
+  }
 });
 
 function showProcessingIndicator(toolbox, operation) {
@@ -336,20 +374,17 @@ function watchForDynamicInputs() {
   const observer = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
       mutation.addedNodes.forEach((node) => {
-        if (node.nodeType === Node.ELEMENT_NODE) {
-          if (
-            node.tagName === "INPUT" &&
-            node.type === "file" &&
-            !node.dataset.formEaseId
-          ) {
-            setupFileInput(node);
-          }
-          const fileInputs =
-            node.querySelectorAll?.('input[type="file"]') || [];
-          fileInputs.forEach((input) => {
-            if (!input.dataset.formEaseId) setupFileInput(input);
-          });
+        if (
+          node.tagName === "INPUT" &&
+          node.type === "file" &&
+          !node.dataset.formEaseId
+        ) {
+          setupFileInput(node);
         }
+        const fileInputs = node.querySelectorAll?.('input[type="file"]') || [];
+        fileInputs.forEach((input) => {
+          if (!input.dataset.formEaseId) setupFileInput(input);
+        });
       });
     });
   });

--- a/toolbox.html
+++ b/toolbox.html
@@ -1,70 +1,131 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Toolbox</title>
-  </head>
-  <body>
-    <div class="formease-toolbox">
-      <!---Basic Template-->
-      <h4>FormEase Toolbox</h4>
 
-      <!-- Dropdown -->
-      <div id="dropdown">
-        <label for="task">Choose what you want to do : </label>
-        <select id="task" name="task">
-          <option value="nill">Select</option>
-          <option value="resize">Resize</option>
-          <option value="compress">Compress</option>
-          <option value="convert">Convert</option>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toolbox</title>
+</head>
+
+<body>
+  <div class="formease-toolbox">
+    <!---Basic Template-->
+    <h4>FormEase Toolbox</h4>
+
+    <!-- Dropdown -->
+    <div id="dropdown">
+      <label for="task">Choose what you want to do : </label>
+      <select id="task" name="task">
+        <option value="nill">Select</option>
+        <option value="resize">Resize</option>
+        <option value="compress">Compress</option>
+        <option value="convert">Convert</option>
+      </select>
+    </div>
+
+    <!-- Basic Range Control -->
+    <div id="resize" class="hidden">
+      <div id="resize-inner">
+        <label for="resize">Resize :</label>
+        <input type="range" id="resize-range" min="10" max="100" value="100" class="ms-4" />
+      </div>
+    </div>
+    <div class="scale-display"></div>
+
+    <!-- Compress Input -->
+    <div id="compress" class="hidden">
+      <div id="compress-inner">
+        <label for="compress-input">Compress to : </label>
+        <input type="number" id="compress-input" name="compress" min="1" max="100" />
+        <span>%</span>
+      </div>
+    </div>
+
+    <!-- Convert Dropdown -->
+    <div id="convert" class="hidden">
+      <div id="convert-inner">
+        <label for="convert-dropdown">Convert to : </label>
+        <select id="convert-dropdown" name="convert">
+          <option value="PNG" selected>PNG</option>
+          <option value="JPG">JPG</option>
+          <option value="JPEG">JPEG</option>
         </select>
       </div>
-
-      <!-- Basic Range Control -->
-      <div id="resize" class="hidden">
-        <div id="resize-inner">
-          <label for="resize">Resize :</label>
-          <input
-            type="range"
-            id="resize-range"
-            min="10"
-            max="100"
-            value="100"
-            class="ms-4"
-          />
-        </div>
-      </div>
-      <div class="scale-display"></div>
-
-      <!-- Compress Input -->
-      <div id="compress" class="hidden">
-        <div id="compress-inner">
-          <label for="compress-input">Compress to : </label>
-          <input
-            type="number"
-            id="compress-input"
-            name="compress"
-            min="1"
-            max="100"
-          />
-          <span>%</span>
-        </div>
-      </div>
-
-      <!-- Convert Dropdown -->
-      <div id="convert" class="hidden">
-        <div id="convert-inner">
-          <label for="convert-dropdown">Convert to : </label>
-          <select id="convert-dropdown" name="convert">
-            <option value="PNG" selected>PNG</option>
-            <option value="JPG">JPG</option>
-            <option value="JPEG">JPEG</option>
-          </select>
-        </div>
-      </div>
-
-      <button id="apply" class="hidden">Apply</button>
     </div>
-  </body>
+
+    <button id="apply" class="hidden" style="margin-right: 10px;">Apply</button>
+
+    <!-- Reset Button -->
+    <div class="reset-section">
+      <button id="resetButton">Reset</button>
+    </div>
+
+    <!-- Feedback Area -->
+    <div class="formease-feedback" style="display: none; margin-top: 10px; padding: 8px; border-radius: 4px;"></div>
+  </div>
+
+  <script>
+    // Selecting Dropdown & Buttons
+    let dropdown = document.querySelector("#task");
+    let resize = document.querySelector("#resize");
+    let compress = document.querySelector("#compress");
+    let convert = document.querySelector("#convert");
+    let applyButton = document.querySelector("#apply");
+    let resetButton = document.querySelector("#resetButton");
+    let feedbackArea = document.querySelector(".formease-feedback");
+
+    // Making the Dropdown Dynamic
+    dropdown.addEventListener("change", (e) => {
+      dropdown.value = e.target.value;
+
+      // Logic for Visibility of Sections
+      if (dropdown.value === "resize") {
+        resize.classList.remove("hidden");
+        compress.classList.add("hidden");
+        convert.classList.add("hidden");
+        applyButton.classList.remove("hidden");
+      } else if (dropdown.value === "compress") {
+        compress.classList.remove("hidden");
+        resize.classList.add("hidden");
+        convert.classList.add("hidden");
+        applyButton.classList.remove("hidden");
+      } else if (dropdown.value === "convert") {
+        convert.classList.remove("hidden");
+        compress.classList.add("hidden");
+        resize.classList.add("hidden");
+        applyButton.classList.remove("hidden");
+      } else {
+        resize.classList.add("hidden");
+        compress.classList.add("hidden");
+        convert.classList.add("hidden");
+        applyButton.classList.add("hidden");
+      }
+    });
+
+    // Reset Button Functionality
+    resetButton.addEventListener("click", () => {
+      const toolbox = document.querySelector(".formease-toolbox");
+      const inputId = toolbox.dataset.inputId;
+      const input = document.querySelector(`input[data-form-ease-id="${inputId}"]`);
+
+      if (!inputId || !input) {
+        feedbackArea.style.display = "block";
+        feedbackArea.innerHTML = "Error: Input not found.";
+        feedbackArea.style.backgroundColor = "#fef2f2";
+        feedbackArea.style.color = "#dc2626";
+        setTimeout(() => (feedbackArea.style.display = "none"), 3000);
+        return;
+      }
+
+      window.postMessage({ type: "requestReset", inputId }, "*");
+
+      // Temporary feedback
+      feedbackArea.style.display = "block";
+      feedbackArea.innerHTML = "Requesting reset...";
+      feedbackArea.style.backgroundColor = "#dbeafe";
+      feedbackArea.style.color = "#1d4ed8";
+    });
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION

This PR adds a "Reset" button to the FormEase toolbox to allow users to undo file processing (resizing, compressing, or converting) and revert to the original file. Changes include:
- Added a "Reset" button in `toolbox.html` with a click handler to send a `requestReset` message.
- Updated `content.js` to handle the reset, restoring the original file using `originalFiles` and `data-form-ease-id`, clearing `.formease-feedback`, and dispatching a `change` event.
- Added a 10px margin-right to the "Apply" button for spacing between "Apply" and "Reset".


Files Changed :----->
- `toolbox.html`
- `content.js`

![image](https://github.com/user-attachments/assets/e41d564f-8269-40ad-85cf-77c86cd60f06)
![image](https://github.com/user-attachments/assets/1a573867-200d-4a7e-9310-edd8e6d160c4)

