### PR TITLE
fix(ui): Improve floating Edit button styling and responsiveness

### DIFF
--- a/content.js
+++ b/content.js
@@ -63,19 +63,7 @@ function injectFloatingEditButton(input) {
   const editBtn = document.createElement("button");
   editBtn.textContent = "Edit";
   editBtn.className = "formease-edit-btn";
-  editBtn.style.cssText = `
-    position: absolute;
-    right: 5px;
-    top: 5px;
-    z-index: 9999;
-    padding: 4px 10px;
-    background-color: #2563eb;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    font-size: 12px;
-    cursor: pointer;
-  `;
+  /* removed the styling which was giving through js instead of that used external css */
 
   if (input.parentNode && input.parentNode.style) {
     input.parentNode.style.position = "relative";

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content.js"]
+      "js": ["content.js"],
+      "css": ["styles.css"] 
     }
   ],
   "web_accessible_resources": [

--- a/styles.css
+++ b/styles.css
@@ -88,17 +88,17 @@ body {
 }
 
 /* Floating Edit Button */
-.edit-button {
+/*Editing the class name because it create a confusion*/
+.formease-edit-btn {
   position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  background-color: #1d4ed8;
+  right: 5px;
+  top:5px; 
+  background-color:#2563EB;  
   color: white;
   border: none;
-  border-radius: 50px;
-  padding: 0.3rem 0.75rem;
-  font-size: 12px;
+  border-radius: 4px;
+  padding: 0.5rem 1.5rem;
+  font-size: 11px;
   font-weight: bold;
   z-index: 9999;
   cursor: pointer;
@@ -106,8 +106,13 @@ body {
   transition: background-color 0.2s ease-in-out;
 }
 
-.edit-button:hover {
-  background-color: #2563eb;
+.formease-edit-btn:hover {
+  background-color: #1d4ed8;
+}
+/*added focus it will more visually grab the attention*/
+.formease-edit-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);  
 }
 
 .hidden {


### PR DESCRIPTION
Problem : "The floating edit button was overlap issues and not proper styling"
Solution :  "Removed the styling which was giving through the JavaScript, due to bad practice and avoid collide of other element. Instead of that I used external CSS and changed the existing ( edit-btn ) name to ( formease-edit-btn ) and applied the styling, just for enhancement I have given focus for better ux. Also added the css file into the content_scripts in the manifest file."
