### PR TITLE
Fix:#83/ ArpitKaushik2025/Reset Button Functionality

### DIFF
--- a/content.js
+++ b/content.js
@@ -21,9 +21,12 @@ injectScript("scripts/pica.min.js");
 injectScript("scripts/resize.js");
 injectScript("scripts/compress.js");
 injectScript("scripts/convert.js");
+injectScript("scripts/reset.js");
 
 // Initialise File Input Counter
 let fileInputCounter = 0;
+
+let OriginalFile = null;
 
 // Drag & Drop Processing
 const dropZones = document.querySelectorAll(".drop-zone");
@@ -374,7 +377,7 @@ function setupToolboxEventListeners(toolbox, inputId, file = null) {
         } </div>
         <div>
         <span style="background-color: #f3f4f6; padding: 4px 6px; border-radius: 4px;">
-          Original: ${sizeKB} KB
+          Original size : ${sizeKB} KB
         </span><span id="new-size" style="background-color: #f3f4f6; padding: 4px 6px; border-radius: 4px;"></span></div>
       `;
       }
@@ -453,9 +456,12 @@ function setupToolboxEventListeners(toolbox, inputId, file = null) {
   if (dropdown && !dropdown.dataset.listenerAdded) {
     dropdown.addEventListener("change", (e) => {
       const applyBtn = toolbox.querySelector("#apply");
+      const resetBtn = toolbox.querySelector("#resetButton");
 
       dropdown.value = e.target.value;
       dropdown.dataset.listenerAdded = "true";
+
+      const currentFile = getCurrentFileForInput(inputId);
 
       if (dropdown.value === "resize") {
         resizeScale.classList.remove("hidden");
@@ -471,13 +477,23 @@ function setupToolboxEventListeners(toolbox, inputId, file = null) {
         }
         if (applyBtn && !applyBtn.dataset.listenerAdded) {
           applyBtn.addEventListener("click", () => {
-            const currentFile = getCurrentFileForInput(inputId);
             console.log(currentFile);
+
+            OriginalFile = currentFile;
 
             if (currentFile) {
               window.postMessage({ type: "resize", inputId }, "*");
             }
             applyBtn.dataset.listenerAdded = "true";
+          });
+        }
+        if (resetBtn && !resetBtn.dataset.listenerAdded) {
+          resetBtn.addEventListener("click", () => {
+            if (OriginalFile) {
+              window.postMessage({ type: "reset", inputId, OriginalFile }, "*");
+              OriginalFile = null;
+            }
+            resetBtn.dataset.listenerAdded = "true";
           });
         }
       } else if (dropdown.value === "compress") {
@@ -496,6 +512,15 @@ function setupToolboxEventListeners(toolbox, inputId, file = null) {
             applyBtn.dataset.listenerAdded = "true";
           });
         }
+        if (resetBtn && !resetBtn.dataset.listenerAdded) {
+          resetBtn.addEventListener("click", () => {
+            if (OriginalFile) {
+              window.postMessage({ type: "reset", inputId, OriginalFile }, "*");
+              OriginalFile = null;
+            }
+            resetBtn.dataset.listenerAdded = "true";
+          });
+        }
       } else if (dropdown.value === "convert") {
         resizeScale.classList.add("hidden");
         convert.classList.remove("hidden");
@@ -511,6 +536,15 @@ function setupToolboxEventListeners(toolbox, inputId, file = null) {
               showError(toolbox, "Please select a file first");
             }
             applyBtn.dataset.listenerAdded = "true";
+          });
+        }
+        if (resetBtn && !resetBtn.dataset.listenerAdded) {
+          resetBtn.addEventListener("click", () => {
+            if (OriginalFile) {
+              window.postMessage({ type: "reset", inputId, OriginalFile }, "*");
+              OriginalFile = null;
+            }
+            resetBtn.dataset.listenerAdded = "true";
           });
         }
       } else {

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
         "toolbox.html",
         "styles.css",
         "content.js",
+        "scripts/reset.js",
         "scripts/pica.min.js",
         "scripts/resize.js",
         "scripts/compress.js",

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "description": "Resize, compress, and convert files before uploading, directly in-browser.",
   "permissions": ["scripting", "activeTab"],
-  "host_permissions": ["<all_urls>"], 
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_icon": "icons/logo.png",
     "default_title": "FormEase"
@@ -14,7 +14,7 @@
       "matches": ["<all_urls>"],
       "js": ["content.js"],
       "css": ["styles.css"],
-       "all_frames": true
+      "all_frames": true
     }
   ],
   "web_accessible_resources": [

--- a/scripts/reset.js
+++ b/scripts/reset.js
@@ -1,0 +1,66 @@
+window.addEventListener("message", async (event) => {
+  if (event.source === window && event.data.type === "reset") {
+    const { inputId, OriginalFile } = event.data;
+
+    console.log(
+      `[FormEase-Reset] Processing reset request for input ${inputId}`
+    );
+
+    console.log("[FormEase-Reset] Reset Logic called");
+
+    document.getElementById("resize-scale").innerText = "";
+
+    document.getElementById("resize-range").value = 100;
+
+    document.getElementById("img-width").value = 0;
+    document.getElementById("img-height").value = 0;
+
+    document.getElementById("compress-input").value = 0;
+
+    document.getElementById("convert-dropdown").value = "PNG";
+
+    const fileInput = document.querySelector(
+      `input[type="file"][data-form-ease-id=${inputId}]`
+    );
+    console.log(
+      `[FormEase-Reset] File Input taken for resetting with formeaseId ${inputId} : `,
+      fileInput
+    );
+
+    const feedbackArea = document.querySelector(".formease-feedback");
+
+    let width = 0;
+    let height = 0;
+    const sizeKB = (OriginalFile.size / 1024).toFixed(2);
+
+    if (!fileInput || !OriginalFile) {
+      feedbackArea.style.display = "block";
+      feedbackArea.innerHTML =
+        "<div>Error: Input or original file not found.</div>";
+      feedbackArea.style.backgroundColor = "#fef2f2";
+      feedbackArea.style.color = "#dc2626";
+      setTimeout(() => (feedbackArea.style.display = "none"), 10000);
+      return;
+    }
+
+    const img = new Image();
+    img.src = URL.createObjectURL(OriginalFile);
+
+    img.onload = () => {
+      console.log("Image reset");
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(OriginalFile);
+      fileInput.files = dataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+      width = img.width;
+      height = img.height;
+    };
+    setTimeout(() => {
+      feedbackArea.style.display = "block";
+      feedbackArea.innerHTML = `<div>Original file restored.</div><div><em>Click <strong>Confirm</strong> button below the image preview to add original file to input field.</em></div><div>Resolution : ${width} X ${height}</div><div>Original Size : ${sizeKB} kB`;
+      feedbackArea.style.backgroundColor = "#d1fae5";
+      feedbackArea.style.color = "#065f46";
+    }, 100);
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -86,8 +86,8 @@ body {
 
 /* Buttons inside toolbox */
 .toolbox-btn {
-  background-color: #4ade80;       /* Green (Base) */
-  color: #065f46;                  /* Dark green text */
+  background-color: #4ade80; /* Green (Base) */
+  color: #065f46; /* Dark green text */
   border: none;
   border-radius: 0.5rem;
   padding: 0.6rem 1.2rem;
@@ -121,6 +121,7 @@ body {
 #resetButton {
   background-color: rgba(128, 128, 128, 0.641);
   color: #f0fdf4;
+  margin-top: 1rem;
 }
 
 #resetButton:hover {
@@ -184,7 +185,6 @@ body {
   font-size: 0.95rem;
   color: #047857;
 }
-
 
 /* test.html styling */
 
@@ -259,6 +259,15 @@ body {
   }
 }
 
+/* 
+// Highlighting elements */
+.highlight {
+  outline: 2px solid #60a5fa;
+  box-shadow: 0 0 10px #60a5fa;
+}
+
+/* Improved Feedback Wrapper */
+
 /* Add other styles before this comment */
 
 /* For hiding and unhiding objects */
@@ -268,11 +277,3 @@ due to precedence */
 .hidden {
   display: none;
 }
-/* 
-// Highlighting elements */
-.highlight{
-  outline: 2px solid #60a5fa;
-  box-shadow: 0 0 10px #60a5fa;
-}
-
-/* Improved Feedback Wrapper */

--- a/toolbox.html
+++ b/toolbox.html
@@ -34,8 +34,9 @@
             ></em
           >
           <div class="manual-dimension">
-            <label for="resize">Resize :</label>
+            <label for="resize-range">Resize :</label>
             <span>
+              <label for="img-width">Width</label>
               <input
                 type="number"
                 placeholder="width"
@@ -45,6 +46,7 @@
               /> </span
             ><span>X</span
             ><span>
+              <label for="img-height">Height</label>
               <input
                 type="number"
                 placeholder="height"
@@ -88,22 +90,23 @@
         <div id="convert-inner">
           <label for="convert-dropdown">Convert to : </label>
           <select id="convert-dropdown" name="convert">
-            <option value="PNG" selected>PNG</option>
-            <option value="JPG">JPG</option>
-            <option value="JPEG">JPEG</option>
+            <option value="PNG" id="PNG" selected>PNG</option>
+            <option value="JPG" id="JPG">JPG</option>
+            <option value="JPEG" id="JPEG">JPEG</option>
           </select>
         </div>
       </div>
 
       <!-- Apply Button for all 3 actions (resize, compress, convert) -->
-      <button id="apply" class="toolbox-btn ">Apply</button>
+      <button id="apply" class="toolbox-btn">Apply</button>
 
       <!-- Reset Button -->
       <div class="reset-section">
         <button id="resetButton" class="toolbox-btn">Reset</button>
       </div>
+
       <!-- Feedback Area -->
-      <div class="formease-feedback hidden">
+      <div class="formease-feedback">
         <h5>Result Summary</h5>
         <div class="feedback-details">
           <div class="feedback-block">
@@ -119,7 +122,6 @@
         </div>
         <p id="feedback-message">Processing complete.</p>
       </div>
-
 
       <!-- Image Preview Area Apply -->
       <div
@@ -143,96 +145,5 @@
 
     <!-- Confirm Button to add resized image to input -->
     <button id="confirm-btn" class="toolbox-btn hidden">Confirm</button>
-
-    <script>
-      const dropdown = document.getElementById("task");
-      const applyButton = document.getElementById("apply");
-      const fileInput = document.getElementById("resize-file-input");
-      const previewImg = document.getElementById("image-preview");
-      const previewArea = document.getElementById("image-preview-area");
-      const feedbackArea = document.querySelector(".formease-feedback");
-      const resetButton = document.querySelector("#resetButton");
-
-      let originalFile = null;
-
-      fileInput.addEventListener("change", (event) => {
-        const file = event.target.files[0];
-        if (file) {
-          originalFile = file;
-          previewImg.src = URL.createObjectURL(file);
-          previewArea.style.display = "block";
-        }
-      });
-
-      resetButton.addEventListener("click", () => {
-        const toolbox = document.querySelector(".formease-toolbox");
-
-        if (!fileInput || !originalFile) {
-          feedbackArea.style.display = "block";
-          feedbackArea.innerHTML = "Error: Input or original file not found.";
-          feedbackArea.style.backgroundColor = "#fef2f2";
-          feedbackArea.style.color = "#dc2626";
-          setTimeout(() => (feedbackArea.style.display = "none"), 3000);
-          return;
-        }
-
-        const dataTransfer = new DataTransfer();
-        dataTransfer.items.add(originalFile);
-        fileInput.files = dataTransfer.files;
-        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
-
-        previewArea.style.display = "none";
-        feedbackArea.style.display = "block";
-        feedbackArea.innerHTML = "Original file restored.";
-        feedbackArea.style.backgroundColor = "#d1fae5";
-        feedbackArea.style.color = "#065f46";
-        setTimeout(() => (feedbackArea.style.display = "none"), 3000);
-
-        window.postMessage(
-          {
-            type: "storeOriginal",
-            inputId: toolbox.dataset.inputId,
-            file: originalFile,
-          },
-          "*"
-        );
-      });
-
-      function showFeedback(originalFile, modifiedFile) {
-        const originalPreview = document.getElementById("original-preview");
-        const modifiedPreview = document.getElementById("modified-preview");
-        const originalSize = document.getElementById("original-size");
-        const modifiedSize = document.getElementById("modified-size");
-        const feedbackMsg = document.getElementById("feedback-message");
-
-        originalPreview.src = URL.createObjectURL(originalFile);
-        modifiedPreview.src = URL.createObjectURL(modifiedFile);
-        originalSize.textContent = `Size: ${(originalFile.size / 1024).toFixed(2)} KB`;
-        modifiedSize.textContent = `Size: ${(modifiedFile.size / 1024).toFixed(2)} KB`;
-        feedbackMsg.textContent = "Successfully processed and previewed!";
-
-        feedbackArea.classList.remove("hidden");
-      }
-
-      dropdown.addEventListener("change", () => {
-        const selected = dropdown.value;
-
-        document
-          .querySelectorAll("#resize, #compress, #convert")
-          .forEach((section) => section.classList.add("hidden"));
-
-        if (selected !== "nill") {
-          document.getElementById(selected).classList.remove("hidden");
-          applyButton.classList.remove("hidden");
-        } else {
-          applyButton.classList.add("hidden");
-        }
-      });
-
-      applyButton.addEventListener("click", () => {
-        console.log("Clicked in toolbox");
-        // Here you'd call your processing logic and then showFeedback()
-      });
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## This PR made the Reset button functional.

### What all I did :
1. Made another file `scripts/reset.js`.
2. Updated `manifest.json` to provide the `reset.js` script.
3. Updated `content.js` to inject the `resize.js` script.
4. Removed script from `toolbox.html` since it was no longer needed.
6. Updated `content.js` to post window message on clicking reset button.
7. This message will be received by `reset.js`.
8. Added code for reset in `reset.js`
9. Toolbox fields also reset on clicking reset button.

---

### Additional Fix : 
1. Fix a minor bug in `resize.js` which was making feedback area rigid and its content was not changing on other operations.
2. Added space in between apply button and reset button by styling in `styles.css`.
3. Added spacing in between old and new comparison in feedback using inline CSS.
4. Added labels for manual dimensions for resize.

---

### Note : 
**The current logic for reset is working fine and tested only for resize functionality.**

Reference for the note : 
Currently there is some functionality that on selecting compress and convert and then clicking the apply button, the file gets injected in input field and the toolbox is sort of closed automatically hiding the apply and reset buttons.

---

### Issues found : 
1. compress and convert apply button directly inject new file in input field, hiding the apply and reset buttons, making it impossible to reset.
2. The new resize image is not accepted in google forms as there is a policy of google forms to not accept **blobs** as input, which is being currently used in our resize logic.

---

### Request: 
This blob issue I have figured out, and I know how to fix it, since in that the code for resize in `resize.js` needs to be touched and I know exactly what part to change so I guess it will be beneficial that I handle that issue. (requesting just for this)
As it might break the resize logic if handled by someone else.

--- 

### Images

Adding images for better and fast reviewing.

1. Space between apply and resize buttons

<img width="1088" height="408" alt="1" src="https://github.com/user-attachments/assets/ab960892-f2e4-4897-845f-ba1aa6f32654" />


2. Labels for manual dimensions for resize

<img width="690" height="442" alt="2" src="https://github.com/user-attachments/assets/4495e878-8f03-4fc9-9d46-06a909f3ab69" />


3. Spacing between old and new comparison

<img width="961" height="200" alt="3" src="https://github.com/user-attachments/assets/8013b61d-a01b-48da-ab5e-b6f960b0cb86" />


4. Feedback and toolbox preview after pressing reset button

<img width="1017" height="607" alt="4" src="https://github.com/user-attachments/assets/05b2c7fc-9f80-4f9d-8b9c-38770fd75b14" />


---


Fix: #83 

