### PR TITLE
Fix: #95/Arpit kaushik2025/compress convert logic

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,14 +4,14 @@
   "version": "1.0",
   "description": "Resize, compress, and convert files before uploading, directly in-browser.",
   "permissions": ["scripting", "activeTab"],
-  "host_permissions": ["<all_urls>"],
+  "host_permissions": ["https://docs.google.com/*"],
   "action": {
     "default_icon": "icons/logo.png",
     "default_title": "FormEase"
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://docs.google.com/*"],
       "js": ["content.js"],
       "css": ["styles.css"],
       "all_frames": true

--- a/manifest.json
+++ b/manifest.json
@@ -4,14 +4,14 @@
   "version": "1.0",
   "description": "Resize, compress, and convert files before uploading, directly in-browser.",
   "permissions": ["scripting", "activeTab"],
-  "host_permissions": ["https://docs.google.com/*"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_icon": "icons/logo.png",
     "default_title": "FormEase"
   },
   "content_scripts": [
     {
-      "matches": ["https://docs.google.com/*"],
+      "matches": ["<all_urls>"],
       "js": ["content.js"],
       "css": ["styles.css"],
       "all_frames": true

--- a/scripts/compress.js
+++ b/scripts/compress.js
@@ -133,7 +133,7 @@ window.addEventListener("message", async (event) => {
       console.log(
         "[FormEase-Compress] Confirm Button click event fired for compress."
       );
-      const newFile = new File([blob], `Resized: ${file.name}`, {
+      const newFile = new File([blob], `Compressed: ${file.name}`, {
         type: blob.type,
         lastModified: Date.now(),
       });

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -1,147 +1,211 @@
 /**
  * FormEase Convert Script
- * Handles image format conversion between different file types
+ * Handles image conversion to reduce file size while maintaining reasonable quality
  * Communicates with the main content script via postMessage API
  */
 
-window.addEventListener('message', (event) => {
-  // Only process convert requests from the same window
-  if (event.source === window && event.data.type === 'convert') {
-    const { inputId, file, format, timeoutId } = event.data;
-    
-    console.log(`[FormEase-Convert] Processing convert request for input ${inputId}, target format: ${format}`);
-    
-    // Call the convert function with enhanced callback
-    convertImage(file, format, (convertedFile, error) => {
-      if (error) {
-        console.error(`[FormEase-Convert] Conversion failed for input ${inputId}:`, error);
-        window.postMessage({ 
-          type: 'fileProcessingError', 
-          error: error.message, 
-          inputId: inputId, 
-          operation: 'convert',
-          timeoutId: timeoutId
-        }, '*');
-      } else {
-        console.log(`[FormEase-Convert] Conversion completed for input ${inputId}. From ${file.type} to ${convertedFile.type}`);
-        window.postMessage({ 
-          type: 'fileProcessed', 
-          file: convertedFile, 
-          inputId: inputId, 
-          originalOperation: 'convert',
-          originalFormat: file.type,
-          newFormat: convertedFile.type,
-          originalSize: file.size,
-          newSize: convertedFile.size,
-          timeoutId: timeoutId
-        }, '*');
-      }
+window.addEventListener("message", async (event) => {
+  // Only process compress requests from the same window
+  if (event.source === window && event.data.type === "convert") {
+    const { inputId, mimeType } = event.data;
+
+    const mime = mimeType.toLowerCase();
+    const fileType = `image/${mime}`;
+
+    const feedbackArea = document.querySelector(".formease-feedback");
+
+    const toolbox = document.querySelector(
+      `.formease-toolbox[data-input-id="${inputId}"]`
+    );
+
+    console.log(
+      `[FormEase-Convert] Processing convert request for input ${inputId}`
+    );
+
+    console.log("[FormEase-Convert] Convert Logic called");
+
+    console.log(
+      "[FormEase-Convert] File type in which conversion is to be done : ",
+      fileType
+    );
+
+    const fileInput = document.querySelector(
+      `input[type="file"][data-form-ease-id=${inputId}]`
+    );
+    console.log(
+      `[FormEase-Convert] File taken for converting with formeaseId ${inputId} : `,
+      fileInput.files[0]
+    );
+
+    let blob = null;
+
+    const previewArea = document.getElementById("image-preview-area");
+    const previewImg = document.getElementById("image-preview");
+
+    const convertDropdown = document.getElementById("convert-dropdown");
+
+    const confirmButton = document.getElementById("confirm-btn");
+
+    const file = fileInput.files[0];
+
+    originalType = file.type;
+
+    const convertingFeedback = () => {
+      feedbackArea.style.display = "block";
+      feedbackArea.innerHTML = "<span>ℹ️ Converting...</span>";
+      feedbackArea.style.backgroundColor = "#dbeafe";
+      feedbackArea.style.color = "#1d4ed8";
+      return;
+    };
+
+    const errorFeedback = () => {
+      feedbackArea.innerHTML = "<span>⚠️ Error converting file.</span>";
+      feedbackArea.style.backgroundColor = "#fef2f2";
+      feedbackArea.style.color = "#dc2626";
+      feedbackArea.style.boxShadow = "rgba(219, 0, 0, 1) 0px 5px 15px;";
+      return;
+    };
+
+    const createBitmap = async (file) => {
+      const img = new Image();
+
+      const reader = new FileReader();
+      const dataURL = await new Promise((resolve, reject) => {
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+
+      img.src = dataURL;
+      await img.decode();
+
+      const bitmap = await createImageBitmap(img);
+
+      return bitmap;
+    };
+
+    const createTargetCanvas = (bitmap) => {
+      const canvas = document.createElement("canvas");
+      canvas.width = bitmap.width;
+      canvas.height = bitmap.height;
+
+      const ctx = canvas.getContext("2d");
+
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      ctx.drawImage(bitmap, 0, 0);
+
+      return canvas;
+    };
+
+    const convertToBlob = (canvas, newMimeType) => {
+      return new Promise((resolve, reject) => {
+        canvas.toBlob(
+          (resizedBlob) => {
+            console.log("[FormEase-Convert] Image Converted Successfully");
+            console.log("[FormEase-Compress] Converted Blob : ", resizedBlob);
+
+            blob = resizedBlob;
+
+            const newType = resizedBlob.type;
+
+            const reader = new FileReader();
+            reader.onload = () => {
+              previewImg.src = reader.result;
+              previewArea.style.display = "block";
+              confirmButton.classList.remove("hidden");
+            };
+            reader.readAsDataURL(resizedBlob);
+
+            console.log("[FormEase-Convert] Image loaded and ready to insert.");
+            console.log(newType);
+            resolve(newType);
+
+            previewImg.onerror = () => {
+              reject(new Error("Failed to load preview image"));
+            };
+          },
+          newMimeType,
+          0.9
+        );
+      });
+    };
+
+    confirmButton.addEventListener("click", () => {
+      console.log(
+        "[FormEase-Compress] Confirm Button click event fired for compress."
+      );
+      const newFile = new File([blob], `Resized: ${file.name}`, {
+        type: fileType,
+        lastModified: Date.now(),
+      });
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(newFile);
+      fileInput.files = dataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+      console.log("[FormEase-Compress] Resized Image added to Input.");
+
+      confirmButton.classList.add("hidden");
+      convertDropdown.value = "PNG";
+
+      setTimeout(() => {
+        previewArea.remove();
+        toolbox.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
+        feedbackArea.style.display = "block";
+        feedbackArea.innerHTML = "<div>✅ File Injected Successfully!";
+        feedbackArea.style.boxShadow = "rgba(46, 242, 11, 1) 0px 5px 15px;";
+      }, 100);
+
+      setTimeout(() => {
+        toolbox.remove();
+      }, 3000);
     });
+
+    if (!file) {
+      feedbackArea.style.display = "block";
+      feedbackArea.innerHTML = "⚠️ Please select a file before applying.";
+      feedbackArea.style.backgroundColor = "#fef2f2";
+      feedbackArea.style.color = "#dc2626";
+      alert("Please select a file before applying resize.");
+      setTimeout(() => (feedbackArea.style.display = "none"), 3000);
+      return;
+    }
+
+    if (fileType !== "") {
+      convertingFeedback();
+
+      console.log("[FormEase-Convert] Converting the file.");
+
+      try {
+        const bitmap = await createBitmap(file);
+
+        const canvas = createTargetCanvas(bitmap);
+
+        const newType = await convertToBlob(canvas, fileType);
+
+        feedbackArea.innerHTML = `<div style="margin-bottom:1rem;">✅ Converted, please review.</div><div>Original Type : ${originalType}</div><div style="margin-top: 1rem;">New Type : ${newType}</div>`;
+        feedbackArea.style.backgroundColor = "#d1fae5";
+        feedbackArea.style.color = "#065f46";
+
+        setTimeout(() => (feedbackArea.style.display = "none"), 1500);
+
+        setTimeout(() => {
+          feedbackArea.style.display = "block";
+          feedbackArea.innerHTML =
+            "<div>ℹ️ Press the <strong><em>Save Changes</em></strong></div> below the image to finalize and inject the file in the input.";
+          feedbackArea.style.backgroundColor = "#d1fae5";
+          feedbackArea.style.color = "#065f46";
+        }, 1500);
+      } catch (error) {
+        console.error("Resize error:", error);
+        errorFeedback();
+      }
+    }
   }
 });
-
-/**
- * Convert an image file to a different format
- * @param {File} file - The original image file
- * @param {string} format - Target format ('jpeg', 'png', 'webp')
- * @param {Function} callback - Callback function (convertedFile, error)
- */
-function convertImage(file, format, callback) {
-  // Validate input parameters
-  if (!file || !file.type.startsWith('image/')) {
-    callback(null, new Error('Invalid file type. Only image files are supported.'));
-    return;
-  }
-  
-  // Supported formats
-  const supportedFormats = ['jpeg', 'jpg', 'png', 'webp'];
-  if (!supportedFormats.includes(format.toLowerCase())) {
-    callback(null, new Error(`Unsupported format. Supported formats: ${supportedFormats.join(', ')}`));
-    return;
-  }
-  
-  // Normalize format
-  const targetFormat = format.toLowerCase() === 'jpg' ? 'jpeg' : format.toLowerCase();
-  const mimeType = `image/${targetFormat}`;
-  
-  // Check if conversion is actually needed
-  if (file.type === mimeType) {
-    console.log(`[FormEase-Convert] File is already in ${targetFormat} format`);
-    callback(file, null);
-    return;
-  }
-  
-  const reader = new FileReader();
-  
-  // Handle file reading errors
-  reader.onerror = function() {
-    callback(null, new Error('Failed to read the file'));
-  };
-  
-  reader.onload = function(event) {
-    const img = new Image();
-    
-    // Handle image loading errors
-    img.onerror = function() {
-      callback(null, new Error('Failed to load the image. The file may be corrupted.'));
-    };
-    
-    img.onload = function() {
-      try {
-        console.log(`[FormEase-Convert] Converting image: ${img.width}x${img.height} from ${file.type} to ${mimeType}`);
-        
-        const canvas = document.createElement('canvas');
-        canvas.width = img.width;
-        canvas.height = img.height;
-        
-        const ctx = canvas.getContext('2d');
-        
-        // For JPEG conversion, add white background to handle transparency
-        if (targetFormat === 'jpeg') {
-          ctx.fillStyle = '#FFFFFF';
-          ctx.fillRect(0, 0, canvas.width, canvas.height);
-        }
-        
-        // Draw the image onto canvas
-        ctx.drawImage(img, 0, 0);
-        
-        // Convert to blob with appropriate quality
-        const quality = targetFormat === 'jpeg' ? 0.92 : undefined;
-        
-        canvas.toBlob((blob) => {
-          if (!blob) {
-            callback(null, new Error('Failed to convert the image'));
-            return;
-          }
-          
-          // Generate new filename with correct extension
-          let newFileName = file.name;
-          const lastDotIndex = newFileName.lastIndexOf('.');
-          if (lastDotIndex !== -1) {
-            newFileName = newFileName.substring(0, lastDotIndex) + '.' + targetFormat;
-          } else {
-            newFileName = newFileName + '.' + targetFormat;
-          }
-          
-          // Create new File object with converted data
-          const convertedFile = new File([blob], newFileName, {
-            type: mimeType,
-            lastModified: Date.now()
-          });
-          
-          console.log(`[FormEase-Convert] Conversion successful. Size changed from ${file.size} to ${blob.size} bytes`);
-          callback(convertedFile, null);
-          
-        }, mimeType, quality);
-        
-      } catch (error) {
-        console.error('[FormEase-Convert] Unexpected error during conversion:', error);
-        callback(null, new Error(`Unexpected error: ${error.message}`));
-      }
-    };
-    
-    img.src = event.target.result;
-  };
-  
-  reader.readAsDataURL(file);
-}

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -136,7 +136,11 @@ window.addEventListener("message", async (event) => {
       console.log(
         "[FormEase-Compress] Confirm Button click event fired for compress."
       );
-      const newFile = new File([blob], `Resized: ${file.name}`, {
+      const extension = fileType.split("/")[1]; // "jpeg", "png", etc.
+      const baseName = file.name.replace(/\.[^/.]+$/, ""); // strip existing extension
+      const newFileName = `${baseName}.${extension}`;
+
+      const newFile = new File([blob], `Converted: ${newFileName}`, {
         type: fileType,
         lastModified: Date.now(),
       });

--- a/scripts/resize.js
+++ b/scripts/resize.js
@@ -56,7 +56,7 @@ window.addEventListener("message", async (event) => {
 
       const resizingFeedback = () => {
         feedbackArea.style.display = "block";
-        feedbackArea.innerHTML = "<span>ℹ️Resizing...</span>";
+        feedbackArea.innerHTML = "<span>ℹ️ Resizing...</span>";
         feedbackArea.style.backgroundColor = "#dbeafe";
         feedbackArea.style.color = "#1d4ed8";
         return;
@@ -92,6 +92,7 @@ window.addEventListener("message", async (event) => {
         const sourceCanvas = document.createElement("canvas");
         sourceCanvas.width = originalWidth;
         sourceCanvas.height = originalHeight;
+
         sourceCanvas.getContext("2d").drawImage(bitmap, 0, 0);
         return sourceCanvas;
       };
@@ -132,7 +133,9 @@ window.addEventListener("message", async (event) => {
                 const newSize = (resizedBlob.size / 1024).toFixed(2);
                 const sizeSaved = (originalSize - newSize) / originalSize;
                 const percentSaved = (sizeSaved * 100).toFixed(2);
-                console.log("[FormEase] Image loaded and ready to insert.");
+                console.log(
+                  "[FormEase-Resize] Image loaded and ready to insert."
+                );
 
                 resolve([targetHeight, targetWidth, percentSaved, newSize]);
               };
@@ -142,13 +145,15 @@ window.addEventListener("message", async (event) => {
               };
             },
             file.type, // use the original MIME type
-            file.type === "image/jpeg" ? 0.9 : undefined
+            0.9
           );
         });
       };
 
       confirmButton.addEventListener("click", () => {
-        console.log("[FormEase-Resize] Confirm Button click event fired.");
+        console.log(
+          "[FormEase-Resize] Confirm Button click event fired for Resize."
+        );
         const newFile = new File([blob], `Resized: ${file.name}`, {
           type: blob.type,
           lastModified: Date.now(),
@@ -159,7 +164,7 @@ window.addEventListener("message", async (event) => {
         fileInput.files = dataTransfer.files;
         fileInput.dispatchEvent(new Event("change", { bubbles: true }));
 
-        console.log("[FormEase] Resized Image added to Input.");
+        console.log("[FormEase-Resize] Resized Image added to Input.");
 
         confirmButton.classList.add("hidden");
         imgHeight.value = 0;


### PR DESCRIPTION
## This PR improved the workflow of Compress and Convert Logic.

--- 

## What I did:
1. Refactored the content.js to give the control to compress.js and convert.js, uptill now the convert and compress logic was handled by content.js only.
2. Commented out that code, did not delete it, requesting review to delete.
3. The workflow has now been changed, now the file and preview in the toolbox stay there after compressing and converting and get injected on pressing `Save Changes` button.
4. Feedback and tooltips working fine.

---

## Note:
The jpg format is i guess no longer supported as the conversion is not taking place for jpeg, it fallbacks to image/png but it works fine with image/jpeg

--- 

## Issues Found:
When selecting one operation first and clicking on apply then on changing the operation and clicking on apply, both operations run simultaneously.

For eg : I clicked on convert then applied the change by clicking Apply button, then i went to resize to change the operation and clicked apply, then both the functions of resize and convert working together.

---

Suggested Fix:
I suggest having 3 different buttons for 3 different functions which will be visible according to the options selected, and then they perform just the desired operation and only one operation, to reduce confusion and improve UX.

---

Request you to provide me with this issue, as I have made the logic for all 3 functions so ik it best, plus issue raised by me.

Thank you for consideration :)

---

Fix: #95 

