### PR TITLE
#101 - Add Close Button to Toolbox UI

### DIFF
--- a/content.js
+++ b/content.js
@@ -337,7 +337,29 @@ function setupToolboxEventListeners(toolbox, inputId, file = null) {
   const imagePreview = toolbox.querySelector("#image-preview");
   const imagePreviewArea = toolbox.querySelector("#image-preview-area");
   const formeasefeedback = toolbox.querySelector(".formease-feedback");
+  const closeBtn = toolbox.querySelector(".formease-close-btn");
+  if (closeBtn && !closeBtn.dataset.listenerAdded) {
+    closeBtn.addEventListener("click", () => {
+      toolbox.style.display = "none"; // Hide toolbox
 
+      const imagePreview = toolbox.querySelector("#image-preview");
+      const imagePreviewArea = toolbox.querySelector("#image-preview-area");
+      const feedback = toolbox.querySelector(".formease-feedback");
+
+      if (imagePreview && imagePreviewArea) {
+        imagePreview.src = "#";
+        imagePreviewArea.style.display = "none";
+      }
+
+      if (feedback) {
+        feedback.innerHTML = "";
+        feedback.style.display = "none";
+      }
+
+      console.log(`[FormEase] ❌ Closed toolbox for ${inputId}`);
+    });
+    closeBtn.dataset.listenerAdded = "true";
+  }
   if (file && !file.type.startsWith("image/")) {
     toolbox.style.display = "none";
 
@@ -581,6 +603,7 @@ for (let submitBtn of submitBtns) {
     closeToolboxOnSubmit(submitBtn);
   });
 }
+
 
 function closeToolboxOnSubmit(submitBtn) {
   const inputId = submitBtn.closest("form").querySelector('input[type="file"]')

--- a/styles.css
+++ b/styles.css
@@ -272,6 +272,18 @@ body {
   box-shadow: 0 0 10px #60a5fa;
 }
 
+.formease-close-btn{
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: #888;
+  z-index: 9999;
+}
+
 /* Improved Feedback Wrapper */
 
 /* Add other styles before this comment */

--- a/toolbox.html
+++ b/toolbox.html
@@ -11,6 +11,7 @@
     <div class="formease-toolbox">
       <!---Basic Template-->
       <h4>FormEase Toolbox</h4>
+      <button class="formease-close-btn" title="Close Toolbox">❌</button>
 
       <!-- Dropdown -->
       <div id="dropdown">


### PR DESCRIPTION
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ffb41a79-e98f-4a58-9984-6ffdab2b73d7" />
added close button on top right.
it can hide or collapse the toolbox and it can clear the preview or reset selected operations

added function to handle this in control.js

do let me know for any changes ma'am