### PR TITLE
Fix: #154/ feat: Integrated trimming logic with UI

### DIFF
--- a/scripts/trimVideo.js
+++ b/scripts/trimVideo.js
@@ -1,62 +1,81 @@
 import { FFmpeg } from "/assets/ffmpeg/package/dist/esm/index.js";
 import { fetchFile } from "/assets/util/package/dist/esm/index.js";
-let ffmpeg = null;
-const trim = async ({ target: { files } }) => {
-  const message = document.getElementById("message");
-  const startTime = document.getElementById("start-time").value.trim();
-  const endTime = document.getElementById("end-time").value.trim();
 
-  if (!startTime || !endTime) {
-    message.innerHTML = "❌ Please enter both start and end time.";
-    return;
+window.addEventListener("message", async (event) => {
+  if (event.source === window && event.data.type === "trim-video") {
+    let ffmpeg = null;
+    const trim = async ({ target: { files } }) => {
+      const videoFeedbackArea = document.querySelector(
+        ".formease-feedback-video"
+      );
+      document.querySelector(".formease-feedback").innerHTML = "";
+      document.querySelector(".formease-feedback-resize").innerHTML = "";
+      document.querySelector(".formease-feedback-convert").innerHTML = "";
+      document.querySelector(".formease-feedback-reset").innerHTML = "";
+      document.querySelector(".formease-feedback-pdf").innerHTML = "";
+      document.querySelector(".formease-feedback-compress").innerHTML = "";
+
+      const startTime = document.getElementById("start-time").value.trim();
+      const endTime = document.getElementById("end-time").value.trim();
+
+      if (!startTime || !endTime) {
+        videoFeedbackArea.innerHTML =
+          "<div>❌ Please enter both start and end time.</div>";
+        return;
+      }
+
+      if (ffmpeg === null) {
+        ffmpeg = new FFmpeg();
+        ffmpeg.on("log", ({ message }) => {
+          console.log(message);
+        });
+        ffmpeg.on("progress", ({ progress }) => {
+          message.innerHTML = `⏳ ${Math.round(progress * 100)}%`;
+        });
+        await ffmpeg.load({
+          coreURL: "/assets/core/package/dist/umd/ffmpeg-core.js",
+        });
+      }
+
+      try {
+        const file = files[0];
+        const { name } = file;
+
+        await ffmpeg.writeFile(name, await fetchFile(file));
+        videoFeedbackArea.innerHTML = "<div>🚀 Trimming started...</div>";
+
+        await ffmpeg.exec([
+          "-i",
+          name,
+          "-ss",
+          startTime,
+          "-to",
+          endTime,
+          "-vcodec",
+          "libx264",
+          "-crf",
+          "28",
+          "-preset",
+          "veryfast",
+          "-acodec",
+          "aac",
+          "-b:a",
+          "128k",
+          "output.mp4",
+        ]);
+
+        videoFeedbackArea.innerHTML = "<div>✅ Trimming complete.</div>";
+
+        const data = await ffmpeg.readFile("output.mp4");
+        const video = document.getElementById("output-video");
+        video.src = URL.createObjectURL(
+          new Blob([data.buffer], { type: "video/mp4" })
+        );
+
+        document.getElementById("uploader").addEventListener("change", trim);
+      } catch (error) {
+        console.error("Error in trimming the video : ", error);
+      }
+    };
   }
-
-  if (ffmpeg === null) {
-    ffmpeg = new FFmpeg();
-    ffmpeg.on("log", ({ message }) => {
-      console.log(message);
-    });
-    ffmpeg.on("progress", ({ progress }) => {
-      message.innerHTML = `⏳ ${Math.round(progress * 100)}%`;
-    });
-    await ffmpeg.load({
-      coreURL: "/assets/core/package/dist/umd/ffmpeg-core.js",
-    });
-  }
-
-  const file = files[0];
-  const { name } = file;
-
-  await ffmpeg.writeFile(name, await fetchFile(file));
-  message.innerHTML = "🚀 Trimming started...";
-
-  await ffmpeg.exec([
-    "-i",
-    name,
-    "-ss",
-    startTime,
-    "-to",
-    endTime,
-    "-vcodec",
-    "libx264",
-    "-crf",
-    "28",
-    "-preset",
-    "veryfast",
-    "-acodec",
-    "aac",
-    "-b:a",
-    "128k",
-    "output.mp4",
-  ]);
-
-  message.innerHTML = "✅ Trimming complete.";
-
-  const data = await ffmpeg.readFile("output.mp4");
-  const video = document.getElementById("output-video");
-  video.src = URL.createObjectURL(
-    new Blob([data.buffer], { type: "video/mp4" })
-  );
-};
-
-document.getElementById("uploader").addEventListener("change", trim);
+});


### PR DESCRIPTION
## Integrated the trim video logic with UI

---

Found that currently the video preview is displayed in the `formease-feedback` area.
I suggest keeping the feedback containers just for feedback and moving it to a separate div, as it may clash with the feedback innerHTML and might get disappeared.

---

This task will require time as in that I have to align all the feedback divs according to the logic since one new function of trim video is added, and then make new div for previews and inputs of start and end times, then accordingly wire and change the logic at some places, I request you to provide me with this issue with adequate difficulty level and a bit of time.

Fix: #154 